### PR TITLE
Minor fixes to Sliding Lomb Scargle

### DIFF
--- a/src/roto/methods/lombscargle.py
+++ b/src/roto/methods/lombscargle.py
@@ -91,8 +91,24 @@ class LombScarglePeriodFinder(PeriodFinder):
         period_result_estimate: PeriodResult,
         n_periods: int = 5,
         sliding_aggregation: str = "median",
+        max_sliding_windows: int = 100,
         **autopower_kwargs,
-    ):
+    ) -> PeriodResult:
+        """Generate a set of PeriodResults using a sliding window over n_periods.
+
+        Args:
+            period_result_estimate (PeriodResult): First estimate period result
+            n_periods (int, optional): Number of complete periods to consider in each window. Defaults to 5.
+            sliding_aggregation (str, optional): How to aggregate the outputted periods. Defaults to "median". One of ["mean", "median"].
+            max_sliding_windows (int, optional): Max number of sliding windows to consider. Defaults to 100.
+                If period is too short, will cap the number of windows at this value.
+
+        Raises:
+            ValueError: If incorrect method given.
+
+        Returns:
+            PeriodResult: Single PeriodResult with errors calculated using spread across window calculations.
+        """
 
         methods = ["mean", "median"]
         if sliding_aggregation not in methods:
@@ -104,9 +120,10 @@ class LombScarglePeriodFinder(PeriodFinder):
 
         periods = []
         epoch = self.timeseries.min()
+        time_tolerance = np.diff(self.timeseries).min()  # allow a small tolerance when calculating last window
         number_of_windows = (
             int(
-                (self.timeseries.max() - (period_estimate * n_periods))
+                ((self.timeseries.max() + time_tolerance) - (period_estimate * n_periods))
                 / period_estimate
             )
             + 1
@@ -117,10 +134,17 @@ class LombScarglePeriodFinder(PeriodFinder):
                 "Sliding window too large to generate good estimate, returning regular lombscargle"
             )
             return period_result_estimate
+        
+        if number_of_windows > max_sliding_windows:
+            logger.warning(
+                "Attempting to calculate too many sliding windows, reducing to %d" % max_sliding_windows
+            )
+            number_of_windows = max_sliding_windows
+            n_periods = (self.timeseries.max() / period_estimate) - (number_of_windows - 1)
 
         count = 0
         with progressbar.ProgressBar(
-            maxval=number_of_windows,
+            max_value=number_of_windows,
             widgets=[
                 "Sliding LombScargle Window: ",
                 progressbar.Counter(),
@@ -129,7 +153,7 @@ class LombScarglePeriodFinder(PeriodFinder):
                 ")",
             ],
         ) as bar:
-            while epoch <= self.timeseries.max() - (period_estimate * n_periods):
+            while epoch <= (self.timeseries.max() + time_tolerance) - (period_estimate * n_periods):
                 idxs = np.logical_and(
                     self.timeseries >= epoch,
                     self.timeseries < epoch + (period_estimate * n_periods),

--- a/src/roto/methods/lombscargle.py
+++ b/src/roto/methods/lombscargle.py
@@ -120,10 +120,15 @@ class LombScarglePeriodFinder(PeriodFinder):
 
         periods = []
         epoch = self.timeseries.min()
-        time_tolerance = np.diff(self.timeseries).min()  # allow a small tolerance when calculating last window
+        time_tolerance = np.diff(
+            self.timeseries
+        ).min()  # allow a small tolerance when calculating last window
         number_of_windows = (
             int(
-                ((self.timeseries.max() + time_tolerance) - (period_estimate * n_periods))
+                (
+                    (self.timeseries.max() + time_tolerance)
+                    - (period_estimate * n_periods)
+                )
                 / period_estimate
             )
             + 1
@@ -134,13 +139,16 @@ class LombScarglePeriodFinder(PeriodFinder):
                 "Sliding window too large to generate good estimate, returning regular lombscargle"
             )
             return period_result_estimate
-        
+
         if number_of_windows > max_sliding_windows:
             logger.warning(
-                "Attempting to calculate too many sliding windows, reducing to %d" % max_sliding_windows
+                "Attempting to calculate too many sliding windows, reducing to %d"
+                % max_sliding_windows
             )
             number_of_windows = max_sliding_windows
-            n_periods = (self.timeseries.max() / period_estimate) - (number_of_windows - 1)
+            n_periods = (self.timeseries.max() / period_estimate) - (
+                number_of_windows - 1
+            )
 
         count = 0
         with progressbar.ProgressBar(
@@ -153,7 +161,9 @@ class LombScarglePeriodFinder(PeriodFinder):
                 ")",
             ],
         ) as bar:
-            while epoch <= (self.timeseries.max() + time_tolerance) - (period_estimate * n_periods):
+            while epoch <= (self.timeseries.max() + time_tolerance) - (
+                period_estimate * n_periods
+            ):
                 idxs = np.logical_and(
                     self.timeseries >= epoch,
                     self.timeseries < epoch + (period_estimate * n_periods),

--- a/test/methods/test_lombscargle.py
+++ b/test/methods/test_lombscargle.py
@@ -239,9 +239,33 @@ def test_sliding_ls_periodogram_too_short(
         return_value=mock_ls,
     ) as mock_ls_create:
 
-        pr = ls._sliding_ls_periodogram(
+        ls._sliding_ls_periodogram(
             period_result, sliding_aggregation="median", some="kwarg"
         )
 
         assert mock_ls_create.call_count == 100
         assert mock_ls.call_count == 100
+
+
+def test_sliding_ls_periodogram_too_short_user_param(
+    timeseries, flux, period_result
+):
+    ls = LombScarglePeriodFinder(timeseries, flux, flux_errors=None, sliding=True)
+
+    mock_ls = mock.MagicMock()
+    mock_ls.return_value = period_result
+
+    period_result.period = 0.2
+
+    with mock.patch(
+        "roto.methods.lombscargle.LombScarglePeriodFinder",
+        autospec=True,
+        return_value=mock_ls,
+    ) as mock_ls_create:
+
+        ls._sliding_ls_periodogram(
+            period_result, sliding_aggregation="median", max_sliding_windows=20
+        )
+
+        assert mock_ls_create.call_count == 20
+        assert mock_ls.call_count == 20

--- a/test/methods/test_lombscargle.py
+++ b/test/methods/test_lombscargle.py
@@ -217,3 +217,31 @@ def test_sliding_ls_periodogram_period_too_long(
         mock_perc.assert_not_called()
         mock_ls.assert_not_called()
         mock_ls_create.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "period",
+    [0.2, 0.5, 0.8984654, 0.95],
+)
+def test_sliding_ls_periodogram_too_short(
+    period, timeseries, flux, period_result
+):
+    ls = LombScarglePeriodFinder(timeseries, flux, flux_errors=None, sliding=True)
+
+    mock_ls = mock.MagicMock()
+    mock_ls.return_value = period_result
+
+    period_result.period = period
+
+    with mock.patch(
+        "roto.methods.lombscargle.LombScarglePeriodFinder",
+        autospec=True,
+        return_value=mock_ls,
+    ) as mock_ls_create:
+
+        pr = ls._sliding_ls_periodogram(
+            period_result, sliding_aggregation="median", some="kwarg"
+        )
+
+        assert mock_ls_create.call_count == 100
+        assert mock_ls.call_count == 100

--- a/test/methods/test_lombscargle.py
+++ b/test/methods/test_lombscargle.py
@@ -223,9 +223,7 @@ def test_sliding_ls_periodogram_period_too_long(
     "period",
     [0.2, 0.5, 0.8984654, 0.95],
 )
-def test_sliding_ls_periodogram_too_short(
-    period, timeseries, flux, period_result
-):
+def test_sliding_ls_periodogram_too_short(period, timeseries, flux, period_result):
     ls = LombScarglePeriodFinder(timeseries, flux, flux_errors=None, sliding=True)
 
     mock_ls = mock.MagicMock()
@@ -247,9 +245,7 @@ def test_sliding_ls_periodogram_too_short(
         assert mock_ls.call_count == 100
 
 
-def test_sliding_ls_periodogram_too_short_user_param(
-    timeseries, flux, period_result
-):
+def test_sliding_ls_periodogram_too_short_user_param(timeseries, flux, period_result):
     ls = LombScarglePeriodFinder(timeseries, flux, flux_errors=None, sliding=True)
 
     mock_ls = mock.MagicMock()


### PR DESCRIPTION
Create max number of windows to prevent deadlock on short period objects.