### PR TITLE
GP mu prediction edit

### DIFF
--- a/src/roto/methods/gaussianprocess.py
+++ b/src/roto/methods/gaussianprocess.py
@@ -343,11 +343,10 @@ class GPPeriodFinder(PeriodFinder):
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
 
         mu, var = pmx.eval_in_model(
-            self.gp.predict(self.flux_ppt[self.mask], t=timeseries, return_var=True),
+            self.gp.predict(self.flux_ppt[self.mask], t=timeseries, return_var=True, include_mean=True),
             point=self.solution,
             model=self.model,
         )
-        mu += self.solution["mean"]
         std = np.sqrt(var)
 
         # convert data from ppt back into rel flux

--- a/src/roto/methods/gaussianprocess.py
+++ b/src/roto/methods/gaussianprocess.py
@@ -343,7 +343,12 @@ class GPPeriodFinder(PeriodFinder):
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
 
         mu, var = pmx.eval_in_model(
-            self.gp.predict(self.flux_ppt[self.mask], t=timeseries, return_var=True, include_mean=True),
+            self.gp.predict(
+                self.flux_ppt[self.mask],
+                t=timeseries,
+                return_var=True,
+                include_mean=True,
+            ),
             point=self.solution,
             model=self.model,
         )

--- a/src/roto/methods/lombscargle.py
+++ b/src/roto/methods/lombscargle.py
@@ -69,8 +69,6 @@ class LombScarglePeriodFinder(PeriodFinder):
                 "center_data": center_data,
                 "nterms": nterms,
                 "normalization": normalization,
-                "min_ratio_of_maximum_peak_size": min_ratio_of_maximum_peak_size,
-                "samples_per_peak": samples_per_peak,
             }
 
     def __call__(self, **kwargs) -> PeriodResult:

--- a/src/roto/methods/lombscargle.py
+++ b/src/roto/methods/lombscargle.py
@@ -69,8 +69,6 @@ class LombScarglePeriodFinder(PeriodFinder):
                 "center_data": center_data,
                 "nterms": nterms,
                 "normalization": normalization,
-                "min_ratio_of_maximum_peak_size":min_ratio_of_maximum_peak_size,
-                "samples_per_peak":samples_per_peak,
             }
 
     def __call__(self, **kwargs) -> PeriodResult:

--- a/src/roto/methods/lombscargle.py
+++ b/src/roto/methods/lombscargle.py
@@ -69,6 +69,8 @@ class LombScarglePeriodFinder(PeriodFinder):
                 "center_data": center_data,
                 "nterms": nterms,
                 "normalization": normalization,
+                "min_ratio_of_maximum_peak_size":min_ratio_of_maximum_peak_size,
+                "samples_per_peak":samples_per_peak,
             }
 
     def __call__(self, **kwargs) -> PeriodResult:

--- a/src/roto/methods/lombscargle.py
+++ b/src/roto/methods/lombscargle.py
@@ -69,6 +69,8 @@ class LombScarglePeriodFinder(PeriodFinder):
                 "center_data": center_data,
                 "nterms": nterms,
                 "normalization": normalization,
+                "min_ratio_of_maximum_peak_size": min_ratio_of_maximum_peak_size,
+                "samples_per_peak": samples_per_peak,
             }
 
     def __call__(self, **kwargs) -> PeriodResult:


### PR DESCRIPTION
Removed mu += self.solution["mean"] from the _generate_plotting_predictions method in gaussianprocess.py, as the mean value is added by default in gp.predict. Have added "include_mean=True" to the call to gp.predict as a reminder that it's included.